### PR TITLE
pnpm install後にlefthook installを実行するようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "packageManager": "pnpm@8.10.5",
   "scripts": {
+    "postinstall": "lefthook install",
     "task": "task",
     "workspace/client": "pnpm -F @olienttech/client",
     "workspace/server": "pnpm -F @olienttech/server",


### PR DESCRIPTION
This pull request adds a postinstall script to the package.json file. The postinstall script runs the command "lefthook install" after the package is installed. This ensures that the necessary hooks are set up correctly for the project. This change improves the development workflow by automating the installation of hooks.